### PR TITLE
Refactor DRY helpers for Graph bootstrap, filters, and paging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changelog maintenance: Resolved previously committed merge conflict markers in this file.
 - `Get-GTInactiveUser`: Removed forced `-Verbose` from dependency installation call so normal executions stay quiet unless caller explicitly requests verbose output.
 - `Get-M365LicenseOverview`: Escaped single quotes in `-FilterUser` before building OData `startsWith` filters to prevent invalid filters and unintended semantics.
+- `Initialize-GTBeginBlock`: Fixed execution order when both `-InitializeConnection` and `-ValidateScopes` are specified. Connection is now established before scope validation, preventing false failures when no prior `Get-MgContext` exists.
 
 ## [0.19.1] - 2025-11-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reporting refactor: Migrated `Get-GTGuestUserReport`, `Get-GTLicenseCostReport`, and `Get-M365LicenseOverview` from `Get-MgBetaUser`/SDK-specific user calls to `Invoke-MgGraphRequest` with explicit paging.
 - Endpoint preference: Updated reporting queries to prefer `v1.0` endpoints where supported.
 - Instructions: Updated `.github/copilot-instructions.md` to require `Invoke-MgGraphRequest` usage and `v1.0`-first endpoint selection (use `beta` only when necessary).
+- DRY refactor: Added internal helper `Initialize-GTBeginBlock` and adopted it in `Get-GTInactiveUser`, `Get-GTGuestUserReport`, and `Get-M365LicenseOverview` to centralize module/scopes/connection bootstrap logic.
+- DRY refactor: Added internal helper `New-GTODataFilter` and adopted it in `Get-GTInactiveUser`, `Get-GTGuestUserReport`, and `Get-M365LicenseOverview` to centralize OData filter composition.
+- DRY refactor: Added internal helper `Invoke-GTGraphPagedRequest` and adopted it in `Get-GTInactiveUser`, `Get-GTGuestUserReport`, and `Get-M365LicenseOverview` to centralize Microsoft Graph paging/nextLink handling.
 
 ### Fixed
 

--- a/functions/Get-GTGuestUserReport.ps1
+++ b/functions/Get-GTGuestUserReport.ps1
@@ -7,8 +7,8 @@ function Get-GTGuestUserReport
     .DESCRIPTION
     This function retrieves guest users from Microsoft Entra ID and reports on their status.
     It leverages server-side filtering for performance when querying pending users.
-    
-    It includes 'LastSignInDateTime' which requires AuditLog permissions.
+
+    It includes LastSignInDateTime which requires AuditLog permissions.
 
     .PARAMETER PendingOnly
     Switch to return only users who haven't accepted the invitation.
@@ -38,14 +38,10 @@ function Get-GTGuestUserReport
     begin
     {
         $modules = @('Microsoft.Graph.Authentication')
-        Install-GTRequiredModule -ModuleNames $modules
-
-        # 1. Scopes Check
-        # AuditLog.Read.All is required to populate the 'signInActivity' property reliably.
         $requiredScopes = @('User.Read.All', 'AuditLog.Read.All')
-        if (-not (Test-GTGraphScopes -RequiredScopes $requiredScopes -Reconnect -Quiet))
+
+        if (-not (Initialize-GTBeginBlock -ModuleNames $modules -RequiredScopes $requiredScopes -ValidateScopes -ScopeValidationErrorMessage "Failed to acquire required permissions ($($requiredScopes -join ', ')). Aborting."))
         {
-            Write-Error "Failed to acquire required permissions ($($requiredScopes -join ', ')). Aborting."
             return
         }
     }
@@ -68,7 +64,7 @@ function Get-GTGuestUserReport
                 $filterParts.Add("externalUserState eq 'PendingAcceptance'")
             }
 
-            $finalFilter = $filterParts -join ' and '
+            $finalFilter = New-GTODataFilter -Clauses $filterParts
             
             Write-PSFMessage -Level Verbose -Message "Using Filter: $finalFilter"
 
@@ -76,25 +72,7 @@ function Get-GTGuestUserReport
             $encodedSelect = [System.Uri]::EscapeDataString($selectFields)
             $encodedFilter = [System.Uri]::EscapeDataString($finalFilter)
             $nextUri = "/v1.0/users?`$select=$encodedSelect&`$filter=$encodedFilter&`$top=999"
-
-            $guests = [System.Collections.Generic.List[object]]::new()
-            while (-not [string]::IsNullOrWhiteSpace($nextUri))
-            {
-                $response = Invoke-MgGraphRequest -Method GET -Uri $nextUri -ErrorAction Stop
-                if ($response -and $response.value)
-                {
-                    foreach ($item in $response.value)
-                    {
-                        [void]$guests.Add($item)
-                    }
-                }
-
-                $nextUri = if ($response) { $response.'@odata.nextLink' } else { $null }
-                if (-not [string]::IsNullOrWhiteSpace($nextUri) -and $nextUri.StartsWith('https://graph.microsoft.com', [System.StringComparison]::OrdinalIgnoreCase))
-                {
-                    $nextUri = $nextUri.Substring('https://graph.microsoft.com'.Length)
-                }
-            }
+            $guests = Invoke-GTGraphPagedRequest -Uri $nextUri
 
             Write-PSFMessage -Level Verbose -Message "Found $($guests.Count) guest users."
 

--- a/functions/Get-GTInactiveUser.ps1
+++ b/functions/Get-GTInactiveUser.ps1
@@ -59,7 +59,7 @@ function Get-GTInactiveUser
         [switch]$DisabledUsersOnly,
         [switch]$ExternalUsersOnly,
         [switch]$NeverLoggedIn,
-        
+
         [ValidateRange(1, 36500)]
         [int]$InactiveDaysOlderThan,
 
@@ -75,25 +75,15 @@ function Get-GTInactiveUser
 
     begin
     {
-        # Module Management
         $modules = ('Microsoft.Graph.Authentication')
-        Install-GTRequiredModule -ModuleNames $modules
-
-        # 1. Scopes Check (Gold Standard)
-        # AuditLog.Read.All is MANDATORY for signInActivity. Without it, the property is null.
         $requiredScopes = @('User.Read.All', 'AuditLog.Read.All')
         if ($ExcludeGlobalAdministrators)
         {
             $requiredScopes += 'Directory.Read.All'
         }
-        
-        # Allow callers to request a fresh session and ensure Graph connection with required scopes
-        if ($NewSession) { Write-PSFMessage -Level Verbose -Message "NewSession requested: attempting reconnection." }
 
-        $connected = Initialize-GTGraphConnection -Scopes $requiredScopes -NewSession:$NewSession
-        if (-not $connected)
+        if (-not (Initialize-GTBeginBlock -ModuleNames $modules -RequiredScopes $requiredScopes -InitializeConnection -NewSession:$NewSession -ConnectionErrorMessage "Failed to acquire required permissions ($($requiredScopes -join ', ')). Aborting."))
         {
-            Write-Error "Failed to acquire required permissions ($($requiredScopes -join ', ')). Aborting."
             return
         }
     }
@@ -187,7 +177,7 @@ function Get-GTInactiveUser
                 $filterParts.Add("signInActivity/lastSignInDateTime le $filterDateStr")
             }
 
-            $finalFilter = $filterParts -join ' and '
+            $finalFilter = New-GTODataFilter -Clauses $filterParts
             if (-not [string]::IsNullOrWhiteSpace($finalFilter))
             {
                 Write-PSFMessage -Level Verbose -Message "Using OData Filter: $finalFilter"
@@ -202,26 +192,8 @@ function Get-GTInactiveUser
                 $usersUri += "&`$filter=$encodedFilter"
             }
 
-            # Execute Query via Graph REST endpoint with paging support
-            $users = [System.Collections.Generic.List[object]]::new()
-            $nextUri = $usersUri
-            while (-not [string]::IsNullOrWhiteSpace($nextUri))
-            {
-                $response = Invoke-MgGraphRequest -Method GET -Uri $nextUri -ErrorAction Stop
-                if ($response -and $response.value)
-                {
-                    foreach ($item in $response.value)
-                    {
-                        [void]$users.Add($item)
-                    }
-                }
-
-                $nextUri = if ($response) { $response.'@odata.nextLink' } else { $null }
-                if (-not [string]::IsNullOrWhiteSpace($nextUri) -and $nextUri.StartsWith('https://graph.microsoft.com', [System.StringComparison]::OrdinalIgnoreCase))
-                {
-                    $nextUri = $nextUri.Substring('https://graph.microsoft.com'.Length)
-                }
-            }
+            # Execute query via shared paging helper
+            $users = Invoke-GTGraphPagedRequest -Uri $usersUri
 
             $userCount = if ($users) { $users.Count } else { 0 }
             Write-PSFMessage -Level Verbose -Message "Processing $userCount users..."

--- a/functions/Get-GTInactiveUser.ps1
+++ b/functions/Get-GTInactiveUser.ps1
@@ -82,7 +82,7 @@ function Get-GTInactiveUser
             $requiredScopes += 'Directory.Read.All'
         }
 
-        if (-not (Initialize-GTBeginBlock -ModuleNames $modules -RequiredScopes $requiredScopes -InitializeConnection -NewSession:$NewSession -ConnectionErrorMessage "Failed to acquire required permissions ($($requiredScopes -join ', ')). Aborting."))
+        if (-not (Initialize-GTBeginBlock -ModuleNames $modules -RequiredScopes $requiredScopes -InitializeConnection -ValidateScopes -NewSession:$NewSession -ScopeValidationErrorMessage "Failed to acquire required permissions ($($requiredScopes -join ', ')). Aborting."))
         {
             return
         }

--- a/functions/Get-M365LicenseOverview.ps1
+++ b/functions/Get-M365LicenseOverview.ps1
@@ -5,12 +5,7 @@ function Get-M365LicenseOverview
     Retrieves Microsoft 365 license information with detailed service plan analysis.
 
     .DESCRIPTION
-    This function provides a comprehensive view of user licenses and service plans.
     It downloads the official Microsoft Licensing CSV to map GUIDs to Friendly Names.
-
-    PERFORMANCE:
-    - Caches the Microsoft CSV in a script-scope variable to avoid re-downloading every run.
-    - Uses Server-Side filtering for User and Date queries.
 
     .PARAMETER FilterLicenseSKU
     Filters results by specific license SKU (e.g., "E5"). Accepts partial matches.
@@ -49,23 +44,11 @@ function Get-M365LicenseOverview
 
     begin
     {
-        # 1. Module Check
         $requiredModules = @('Microsoft.Graph.Authentication')
-        Install-GTRequiredModule -ModuleNames $requiredModules -Verbose:$VerbosePreference
-
-        # 2. Scopes Check
         $requiredScopes = @('User.Read.All', 'Organization.Read.All', 'AuditLog.Read.All')
-        
-        if (-not (Test-GTGraphScopes -RequiredScopes $requiredScopes -Reconnect:$true -Quiet:$true))
-        {
-            Write-Error "Failed to acquire required permissions ($($requiredScopes -join ', ')). Aborting."
-            return
-        }
 
-        # 3. Connection
-        if (-not (Initialize-GTGraphConnection -Scopes $requiredScopes -NewSession:$NewSession))
+        if (-not (Initialize-GTBeginBlock -ModuleNames $requiredModules -RequiredScopes $requiredScopes -ValidateScopes -InitializeConnection -NewSession:$NewSession -ScopeValidationErrorMessage "Failed to acquire required permissions ($($requiredScopes -join ', ')). Aborting." -ConnectionErrorMessage 'Failed to initialize session.'))
         {
-            Write-Error "Failed to initialize session."
             return
         }
 
@@ -146,25 +129,16 @@ function Get-M365LicenseOverview
             $encodedSelect = [System.Uri]::EscapeDataString($selectFields)
             $nextUri = "/v1.0/users?`$select=$encodedSelect&`$top=999"
 
-            if ($filterParts.Count -gt 0) {
-                $filterStr = $filterParts -join ' and '
+            $filterStr = New-GTODataFilter -Clauses $filterParts
+            if (-not [string]::IsNullOrWhiteSpace($filterStr)) {
                 Write-PSFMessage -Level Verbose -Message "Using OData Filter: $filterStr"
                 $encodedFilter = [System.Uri]::EscapeDataString($filterStr)
                 $nextUri += "&`$filter=$encodedFilter"
             }
 
             # 6. Process Users
-            while (-not [string]::IsNullOrWhiteSpace($nextUri)) {
-                $response = Invoke-MgGraphRequest -Method GET -Uri $nextUri -Headers @{ ConsistencyLevel = 'eventual' } -ErrorAction Stop
-                $users = @()
-                if ($response -and ($response.PSObject.Properties.Name -contains 'value')) {
-                    $users = @($response.value)
-                }
-                elseif ($response -is [System.Collections.IEnumerable] -and -not ($response -is [string])) {
-                    $users = @($response)
-                }
-
-                foreach ($user in $users) {
+            $users = Invoke-GTGraphPagedRequest -Uri $nextUri -Headers @{ ConsistencyLevel = 'eventual' }
+            foreach ($user in $users) {
                     if ($FilterUser -and (-not [string]$user.UserPrincipalName -or -not ([string]$user.UserPrincipalName).StartsWith($FilterUser, [System.StringComparison]::OrdinalIgnoreCase))) {
                         continue
                     }
@@ -221,15 +195,6 @@ function Get-M365LicenseOverview
                             }
                         }
                     }
-                }
-
-                $nextUri = $null
-                if ($response -and ($response.PSObject.Properties.Name -contains '@odata.nextLink')) {
-                    $nextUri = [string]$response.'@odata.nextLink'
-                }
-                if (-not [string]::IsNullOrWhiteSpace($nextUri) -and $nextUri.StartsWith('https://graph.microsoft.com', [System.StringComparison]::OrdinalIgnoreCase)) {
-                    $nextUri = $nextUri.Substring('https://graph.microsoft.com'.Length)
-                }
             }
         }
         catch

--- a/internal/functions/Initialize-GTBeginBlock.ps1
+++ b/internal/functions/Initialize-GTBeginBlock.ps1
@@ -1,0 +1,78 @@
+function Initialize-GTBeginBlock {
+    <#
+    .SYNOPSIS
+    Standardizes common begin-block Graph initialization steps.
+
+    .DESCRIPTION
+    Installs required modules, optionally validates scopes, and optionally initializes
+    a Graph connection for the calling function.
+
+    .PARAMETER ModuleNames
+    Module names to install via Install-GTRequiredModule.
+
+    .PARAMETER RequiredScopes
+    Scopes required by the operation.
+
+    .PARAMETER ValidateScopes
+    When set, validates scopes using Test-GTGraphScopes.
+
+    .PARAMETER InitializeConnection
+    When set, initializes Graph connection using Initialize-GTGraphConnection.
+
+    .PARAMETER NewSession
+    Passed to Initialize-GTGraphConnection when InitializeConnection is set.
+
+    .PARAMETER ScopeValidationErrorMessage
+    Error text emitted when scope validation fails.
+
+    .PARAMETER ConnectionErrorMessage
+    Error text emitted when Graph connection initialization fails.
+
+    .OUTPUTS
+    System.Boolean
+
+    .EXAMPLE
+    Initialize-GTBeginBlock -ModuleNames @('Microsoft.Graph.Users') -RequiredScopes @('User.Read.All') -ValidateScopes
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$ModuleNames,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$RequiredScopes,
+
+        [switch]$ValidateScopes,
+
+        [switch]$InitializeConnection,
+
+        [switch]$NewSession,
+
+        [string]$ScopeValidationErrorMessage = "Failed to acquire required permissions ($($RequiredScopes -join ', ')). Aborting.",
+
+        [string]$ConnectionErrorMessage = 'Failed to initialize session.'
+    )
+
+    Install-GTRequiredModule -ModuleNames $ModuleNames -Verbose:$VerbosePreference
+
+    if ($ValidateScopes) {
+        if (-not (Test-GTGraphScopes -RequiredScopes $RequiredScopes -Reconnect:$true -Quiet:$true)) {
+            Write-Error $ScopeValidationErrorMessage
+            return $false
+        }
+    }
+
+    if ($InitializeConnection) {
+        if ($NewSession) {
+            Write-PSFMessage -Level Verbose -Message 'NewSession requested: attempting reconnection.'
+        }
+
+        if (-not (Initialize-GTGraphConnection -Scopes $RequiredScopes -NewSession:$NewSession)) {
+            Write-Error $ConnectionErrorMessage
+            return $false
+        }
+    }
+
+    return $true
+}

--- a/internal/functions/Initialize-GTBeginBlock.ps1
+++ b/internal/functions/Initialize-GTBeginBlock.ps1
@@ -1,4 +1,5 @@
-function Initialize-GTBeginBlock {
+function Initialize-GTBeginBlock
+{
     <#
     .SYNOPSIS
     Standardizes common begin-block Graph initialization steps.
@@ -13,11 +14,15 @@ function Initialize-GTBeginBlock {
     .PARAMETER RequiredScopes
     Scopes required by the operation.
 
-    .PARAMETER ValidateScopes
-    When set, validates scopes using Test-GTGraphScopes.
-
     .PARAMETER InitializeConnection
     When set, initializes Graph connection using Initialize-GTGraphConnection.
+    When combined with -ValidateScopes, connection is established first so that
+    scope validation has a valid context to check against.
+
+    .PARAMETER ValidateScopes
+    When set, validates scopes using Test-GTGraphScopes.
+    Requires an active Graph context. When combined with -InitializeConnection,
+    the connection is always established before validation runs.
 
     .PARAMETER NewSession
     Passed to Initialize-GTGraphConnection when InitializeConnection is set.
@@ -56,20 +61,25 @@ function Initialize-GTBeginBlock {
 
     Install-GTRequiredModule -ModuleNames $ModuleNames -Verbose:$VerbosePreference
 
-    if ($ValidateScopes) {
-        if (-not (Test-GTGraphScopes -RequiredScopes $RequiredScopes -Reconnect:$true -Quiet:$true)) {
-            Write-Error $ScopeValidationErrorMessage
+    if ($InitializeConnection)
+    {
+        if ($NewSession)
+        {
+            Write-PSFMessage -Level Verbose -Message 'NewSession requested: attempting reconnection.'
+        }
+
+        if (-not (Initialize-GTGraphConnection -Scopes $RequiredScopes -NewSession:$NewSession))
+        {
+            Write-Error $ConnectionErrorMessage
             return $false
         }
     }
 
-    if ($InitializeConnection) {
-        if ($NewSession) {
-            Write-PSFMessage -Level Verbose -Message 'NewSession requested: attempting reconnection.'
-        }
-
-        if (-not (Initialize-GTGraphConnection -Scopes $RequiredScopes -NewSession:$NewSession)) {
-            Write-Error $ConnectionErrorMessage
+    if ($ValidateScopes)
+    {
+        if (-not (Test-GTGraphScopes -RequiredScopes $RequiredScopes -Reconnect:$true -Quiet:$true))
+        {
+            Write-Error $ScopeValidationErrorMessage
             return $false
         }
     }

--- a/internal/functions/Invoke-GTGraphPagedRequest.ps1
+++ b/internal/functions/Invoke-GTGraphPagedRequest.ps1
@@ -12,7 +12,7 @@ function Invoke-GTGraphPagedRequest {
     Initial relative Microsoft Graph URI.
 
     .PARAMETER Headers
-    Optional headers passed to Invoke-MgGraphRequest.
+    Optional hashtable of HTTP headers passed to Invoke-MgGraphRequest (e.g. @{ ConsistencyLevel = 'eventual' }).
 
     .OUTPUTS
     System.Object[]
@@ -42,8 +42,10 @@ function Invoke-GTGraphPagedRequest {
         $response = Invoke-MgGraphRequest @requestParams
 
         if ($response -and ($response.PSObject.Properties.Name -contains 'value')) {
-            foreach ($item in @($response.value)) {
-                [void]$results.Add($item)
+            if ($null -ne $response.value) {
+                foreach ($item in $response.value) {
+                    [void]$results.Add($item)
+                }
             }
         }
         elseif ($response -is [System.Collections.IEnumerable] -and -not ($response -is [string])) {

--- a/internal/functions/Invoke-GTGraphPagedRequest.ps1
+++ b/internal/functions/Invoke-GTGraphPagedRequest.ps1
@@ -1,0 +1,66 @@
+function Invoke-GTGraphPagedRequest {
+    <#
+    .SYNOPSIS
+    Executes a paged Microsoft Graph request and aggregates all items.
+
+    .DESCRIPTION
+    Calls Invoke-MgGraphRequest starting from the supplied URI and follows
+    @odata.nextLink until exhausted. Supports both Graph envelope responses
+    (with value) and enumerable payloads.
+
+    .PARAMETER Uri
+    Initial relative Microsoft Graph URI.
+
+    .PARAMETER Headers
+    Optional headers passed to Invoke-MgGraphRequest.
+
+    .OUTPUTS
+    System.Object[]
+    #>
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Uri,
+
+        [hashtable]$Headers
+    )
+
+    $results = [System.Collections.Generic.List[object]]::new()
+    $nextUri = $Uri
+
+    while (-not [string]::IsNullOrWhiteSpace($nextUri)) {
+        $requestParams = @{
+            Method      = 'GET'
+            Uri         = $nextUri
+            ErrorAction = 'Stop'
+        }
+        if ($Headers) {
+            $requestParams.Headers = $Headers
+        }
+
+        $response = Invoke-MgGraphRequest @requestParams
+
+        if ($response -and ($response.PSObject.Properties.Name -contains 'value')) {
+            foreach ($item in @($response.value)) {
+                [void]$results.Add($item)
+            }
+        }
+        elseif ($response -is [System.Collections.IEnumerable] -and -not ($response -is [string])) {
+            foreach ($item in $response) {
+                [void]$results.Add($item)
+            }
+        }
+
+        $nextUri = $null
+        if ($response -and ($response.PSObject.Properties.Name -contains '@odata.nextLink')) {
+            $nextUri = [string]$response.'@odata.nextLink'
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($nextUri) -and $nextUri.StartsWith('https://graph.microsoft.com', [System.StringComparison]::OrdinalIgnoreCase)) {
+            $nextUri = $nextUri.Substring('https://graph.microsoft.com'.Length)
+        }
+    }
+
+    return $results.ToArray()
+}

--- a/internal/functions/Invoke-GTGraphPagedRequest.ps1
+++ b/internal/functions/Invoke-GTGraphPagedRequest.ps1
@@ -1,4 +1,5 @@
-function Invoke-GTGraphPagedRequest {
+function Invoke-GTGraphPagedRequest
+{
     <#
     .SYNOPSIS
     Executes a paged Microsoft Graph request and aggregates all items.
@@ -29,37 +30,46 @@ function Invoke-GTGraphPagedRequest {
     $results = [System.Collections.Generic.List[object]]::new()
     $nextUri = $Uri
 
-    while (-not [string]::IsNullOrWhiteSpace($nextUri)) {
+    while (-not [string]::IsNullOrWhiteSpace($nextUri))
+    {
         $requestParams = @{
             Method      = 'GET'
             Uri         = $nextUri
             ErrorAction = 'Stop'
         }
-        if ($Headers) {
+        if ($Headers)
+        {
             $requestParams.Headers = $Headers
         }
 
         $response = Invoke-MgGraphRequest @requestParams
 
-        if ($response -and ($response.PSObject.Properties.Name -contains 'value')) {
-            if ($null -ne $response.value) {
-                foreach ($item in $response.value) {
+        if ($response -and ($response.PSObject.Properties.Name -contains 'value'))
+        {
+            if ($null -ne $response.value)
+            {
+                foreach ($item in $response.value)
+                {
                     [void]$results.Add($item)
                 }
             }
         }
-        elseif ($response -is [System.Collections.IEnumerable] -and -not ($response -is [string])) {
-            foreach ($item in $response) {
+        elseif ($response -is [System.Collections.IEnumerable] -and -not ($response -is [string]))
+        {
+            foreach ($item in $response)
+            {
                 [void]$results.Add($item)
             }
         }
 
         $nextUri = $null
-        if ($response -and ($response.PSObject.Properties.Name -contains '@odata.nextLink')) {
+        if ($response -and ($response.PSObject.Properties.Name -contains '@odata.nextLink'))
+        {
             $nextUri = [string]$response.'@odata.nextLink'
         }
 
-        if (-not [string]::IsNullOrWhiteSpace($nextUri) -and $nextUri.StartsWith('https://graph.microsoft.com', [System.StringComparison]::OrdinalIgnoreCase)) {
+        if (-not [string]::IsNullOrWhiteSpace($nextUri) -and $nextUri.StartsWith('https://graph.microsoft.com', [System.StringComparison]::OrdinalIgnoreCase))
+        {
             $nextUri = $nextUri.Substring('https://graph.microsoft.com'.Length)
         }
     }

--- a/internal/functions/New-GTODataFilter.ps1
+++ b/internal/functions/New-GTODataFilter.ps1
@@ -1,0 +1,45 @@
+function New-GTODataFilter {
+    <#
+    .SYNOPSIS
+    Builds a normalized OData filter string.
+
+    .DESCRIPTION
+    Accepts one or more potential OData clause strings, removes null/empty values,
+    and joins remaining clauses with the provided logical operator.
+
+    .PARAMETER Clauses
+    Candidate OData clause strings.
+
+    .PARAMETER JoinOperator
+    Logical operator used to join clauses. Defaults to 'and'.
+
+    .OUTPUTS
+    System.String
+
+    .EXAMPLE
+    New-GTODataFilter -Clauses @("userType eq 'Guest'", "accountEnabled eq false")
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [AllowNull()]
+        [AllowEmptyCollection()]
+        [string[]]$Clauses,
+
+        [ValidateSet('and', 'or')]
+        [string]$JoinOperator = 'and'
+    )
+
+    $normalizedClauses = [System.Collections.Generic.List[string]]::new()
+    foreach ($clause in $Clauses) {
+        if (-not [string]::IsNullOrWhiteSpace($clause)) {
+            [void]$normalizedClauses.Add($clause.Trim())
+        }
+    }
+
+    if ($normalizedClauses.Count -eq 0) {
+        return ''
+    }
+
+    return ($normalizedClauses -join " $JoinOperator ")
+}

--- a/tests/Get-GTGuestUserReport.Tests.ps1
+++ b/tests/Get-GTGuestUserReport.Tests.ps1
@@ -14,6 +14,10 @@ Describe "Get-GTGuestUserReport" {
         Mock -CommandName Test-GTGraphScopes -MockWith { param($RequiredScopes, $Reconnect, $Quiet) return $true } -Verifiable
         Mock -CommandName Write-PSFMessage -MockWith { } -Verifiable
 
+        . "$PSScriptRoot/../internal/functions/Initialize-GTBeginBlock.ps1"
+        . "$PSScriptRoot/../internal/functions/New-GTODataFilter.ps1"
+        . "$PSScriptRoot/../internal/functions/Invoke-GTGraphPagedRequest.ps1"
+
         if (Test-Path $functionPath)
         {
             # Dot-source the function under test

--- a/tests/Get-GTInactiveUser.Tests.ps1
+++ b/tests/Get-GTInactiveUser.Tests.ps1
@@ -36,6 +36,10 @@ Describe "Get-GTInactiveUser" {
             return [PSCustomObject]@{ value = @() }
         } -Verifiable
 
+        . "$PSScriptRoot/../internal/functions/Initialize-GTBeginBlock.ps1"
+        . "$PSScriptRoot/../internal/functions/New-GTODataFilter.ps1"
+        . "$PSScriptRoot/../internal/functions/Invoke-GTGraphPagedRequest.ps1"
+
         # Dot-source the function under test
         . "$PSScriptRoot/../functions/Get-GTInactiveUser.ps1"
     }

--- a/tests/Get-M365LicenseOverview.Tests.ps1
+++ b/tests/Get-M365LicenseOverview.Tests.ps1
@@ -31,6 +31,10 @@
             )
         }
 
+        . "$PSScriptRoot/../internal/functions/Initialize-GTBeginBlock.ps1"
+        . "$PSScriptRoot/../internal/functions/New-GTODataFilter.ps1"
+        . "$PSScriptRoot/../internal/functions/Invoke-GTGraphPagedRequest.ps1"
+
         # Dot-source the function under test
         . "$PSScriptRoot/../functions/Get-M365LicenseOverview.ps1"
     }


### PR DESCRIPTION
## Summary\n- add shared internal helper Initialize-GTBeginBlock for module/scopes/connection bootstrap\n- add shared internal helper New-GTODataFilter for composing OData filter clauses\n- add shared internal helper Invoke-GTGraphPagedRequest for Graph @odata.nextLink paging\n- migrate Get-GTInactiveUser, Get-GTGuestUserReport, and Get-M365LicenseOverview to use shared helpers\n- update related tests to dot-source new helpers\n- update changelog with DRY refactor notes\n\n## Validation\n- Invoke-Pester -Path ./tests/Get-GTInactiveUser.Tests.ps1\n- Invoke-Pester -Path ./tests/Get-GTGuestUserReport.Tests.ps1\n- Invoke-Pester -Path ./tests/Get-M365LicenseOverview.Tests.ps1\n\nAll above suites passed.