### PR TITLE
Standardize UTC retrieval via Get-UTCTime helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DRY refactor: Added internal helper `Initialize-GTBeginBlock` and adopted it in `Get-GTInactiveUser`, `Get-GTGuestUserReport`, and `Get-M365LicenseOverview` to centralize module/scopes/connection bootstrap logic.
 - DRY refactor: Added internal helper `New-GTODataFilter` and adopted it in `Get-GTInactiveUser`, `Get-GTGuestUserReport`, and `Get-M365LicenseOverview` to centralize OData filter composition.
 - DRY refactor: Added internal helper `Invoke-GTGraphPagedRequest` and adopted it in `Get-GTInactiveUser`, `Get-GTGuestUserReport`, and `Get-M365LicenseOverview` to centralize Microsoft Graph paging/nextLink handling.
+- UTC standardization: Replaced remaining direct `(Get-Date).ToUniversalTime()` calls with `Get-UTCTime` in public functions and aligned `Get-UTCTime` implementation to `[DateTime]::UtcNow`.
 
 ### Fixed
 
@@ -42,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Get-GTInactiveUser`: Removed forced `-Verbose` from dependency installation call so normal executions stay quiet unless caller explicitly requests verbose output.
 - `Get-M365LicenseOverview`: Escaped single quotes in `-FilterUser` before building OData `startsWith` filters to prevent invalid filters and unintended semantics.
 - `Initialize-GTBeginBlock`: Fixed execution order when both `-InitializeConnection` and `-ValidateScopes` are specified. Connection is now established before scope validation, preventing false failures when no prior `Get-MgContext` exists.
+- Tests (`Get-GTLegacyAuthReport`, `Get-GTRiskyAppPermissionReport`): Added missing `Get-UTCTime` stub so test suites work in isolation after those functions adopted the helper.
 
 ## [0.19.1] - 2025-11-21
 

--- a/functions/Get-GTLegacyAuthReport.ps1
+++ b/functions/Get-GTLegacyAuthReport.ps1
@@ -129,7 +129,7 @@ function Get-GTLegacyAuthReport
 
     end
     {
-        $utcNow = (Get-Date).ToUniversalTime()
+        $utcNow = Get-UTCTime
         $startDate = $utcNow.AddDays(-$DaysAgo)
         $filterDate = $startDate.ToString('yyyy-MM-ddTHH:mm:ssZ')
 

--- a/functions/Get-GTLicenseCostReport.ps1
+++ b/functions/Get-GTLicenseCostReport.ps1
@@ -165,7 +165,7 @@ function Get-GTLicenseCostReport
 
     process
     {
-        $utcNow = if (Get-Command Get-UTCTime -ErrorAction SilentlyContinue) { Get-UTCTime } else { (Get-Date).ToUniversalTime() }
+        $utcNow = Get-UTCTime
 
         try
         {

--- a/functions/Get-GTRiskyAppPermissionReport.ps1
+++ b/functions/Get-GTRiskyAppPermissionReport.ps1
@@ -102,7 +102,7 @@ function Get-GTRiskyAppPermissionReport
         }
 
         $report = [System.Collections.Generic.List[PSCustomObject]]::new()
-        $utcNow = (Get-Date).ToUniversalTime()
+        $utcNow = Get-UTCTime
 
         try
         {

--- a/functions/Get-M365LicenseOverview.ps1
+++ b/functions/Get-M365LicenseOverview.ps1
@@ -113,7 +113,7 @@ function Get-M365LicenseOverview
 
             # 5. Build Dynamic Filter
             $filterParts = [System.Collections.Generic.List[string]]::new()
-            $utcNow = (Get-Date).ToUniversalTime()
+            $utcNow = Get-UTCTime
 
             if ($FilterUser) {
                 $escapedFilterUser = $FilterUser.Replace("'", "''")

--- a/internal/functions/Get-UTCTime.ps1
+++ b/internal/functions/Get-UTCTime.ps1
@@ -5,7 +5,7 @@ function Get-UTCTime
     Gets the current UTC time as a DateTime object.
 
     .DESCRIPTION
-    Returns the current UTC time using (Get-Date).ToUniversalTime().
+    Returns the current UTC time using [DateTime]::UtcNow.
     This provides consistent UTC time handling across the GraphTools module.
 
     .EXAMPLE
@@ -23,5 +23,5 @@ function Get-UTCTime
     [OutputType([DateTime])]
     param()
 
-    (Get-Date).ToUniversalTime()
+    [DateTime]::UtcNow
 }

--- a/tests/Get-GTLegacyAuthReport.Tests.ps1
+++ b/tests/Get-GTLegacyAuthReport.Tests.ps1
@@ -4,6 +4,7 @@ if (-not (Get-Command Initialize-GTGraphConnection -ErrorAction SilentlyContinue
 if (-not (Get-Command Test-GTGraphScopes -ErrorAction SilentlyContinue)) { function Test-GTGraphScopes { param([string[]]$RequiredScopes, [switch]$Reconnect, [switch]$Quiet) return $true } }
 if (-not (Get-Command Write-PSFMessage -ErrorAction SilentlyContinue)) { function Write-PSFMessage { param($Level, $Message, $ErrorRecord) } }
 if (-not (Get-Command Get-GTGraphErrorDetails -ErrorAction SilentlyContinue)) { function Get-GTGraphErrorDetails { param($Exception, $ResourceType) return @{ LogLevel = 'Error'; Reason = 'Mock Error'; ErrorMessage = 'Mock Error Message' } } }
+if (-not (Get-Command Get-UTCTime -ErrorAction SilentlyContinue)) { function Get-UTCTime { return [DateTime]::UtcNow } }
 
 ## Mock the validation regex
 $script:GTValidationRegex = @{

--- a/tests/Get-GTRiskyAppPermissionReport.Tests.ps1
+++ b/tests/Get-GTRiskyAppPermissionReport.Tests.ps1
@@ -3,6 +3,7 @@ if (-not (Get-Command Install-GTRequiredModule -ErrorAction SilentlyContinue)) {
 if (-not (Get-Command Initialize-GTGraphConnection -ErrorAction SilentlyContinue)) { function Initialize-GTGraphConnection { param([string[]]$Scopes, [switch]$NewSession, [switch]$SkipConnect) return $true } }
 if (-not (Get-Command Test-GTGraphScopes -ErrorAction SilentlyContinue)) { function Test-GTGraphScopes { param([string[]]$RequiredScopes, [switch]$Reconnect, [switch]$Quiet) return $true } }
 if (-not (Get-Command Write-PSFMessage -ErrorAction SilentlyContinue)) { function Write-PSFMessage { param($Level, $Message, $ErrorRecord) } }
+if (-not (Get-Command Get-UTCTime -ErrorAction SilentlyContinue)) { function Get-UTCTime { return [DateTime]::UtcNow } }
 
 ## (Function will be dot-sourced in BeforeAll to allow Pester mocks to register first)
 


### PR DESCRIPTION
## Summary

Replaces all direct `(Get-Date).ToUniversalTime()` calls with the existing `Get-UTCTime` internal helper for consistency, and aligns the helper's own implementation to `[DateTime]::UtcNow`.

> **Note:** The DRY helper refactoring (`Initialize-GTBeginBlock`, `New-GTODataFilter`, `Invoke-GTGraphPagedRequest`) that was originally part of this branch has been split out and shipped separately in PR #77. This PR contains UTC standardization changes only.

## Changes

- `internal/functions/Get-UTCTime.ps1` — Updated implementation to use `[DateTime]::UtcNow`
- `functions/Get-GTLegacyAuthReport.ps1` — Replaced direct UTC call with `Get-UTCTime`
- `functions/Get-GTRiskyAppPermissionReport.ps1` — Replaced direct UTC call with `Get-UTCTime`
- `functions/Get-M365LicenseOverview.ps1` — Replaced direct UTC call with `Get-UTCTime`
- `functions/Get-GTLicenseCostReport.ps1` — Removed defensive fallback check; uses `Get-UTCTime` directly
- `tests/Get-GTLegacyAuthReport.Tests.ps1` — Added `Get-UTCTime` stub for isolation
- `tests/Get-GTRiskyAppPermissionReport.Tests.ps1` — Added `Get-UTCTime` stub for isolation

## Motivation

DRY follow-up: `Get-UTCTime` already existed as an internal helper but was not consistently used across all functions.